### PR TITLE
Fix: locate headers for NumPy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,8 @@ endif
 # There are some unix/gcc specific paths here. Should be cleaned up in future.
 pymoose: python/moose/_moose.so
 pymoose: CXXFLAGS += -DPYMOOSE $(PYTHON_CFLAGS)
+# fix: add include dir for numpy headers required by pymoose/moosemodule.cpp
+pymoose: CXXFLAGS += -I$(shell python -c 'from numpy import get_include; print get_include()')
 pymoose: OBJLIBS += pymoose/_pymoose.o
 pymoose: LDFLAGS += $(PYTHON_LDFLAGS)
 export CXXFLAGS

--- a/pymoose/moosemodule.cpp
+++ b/pymoose/moosemodule.cpp
@@ -78,7 +78,7 @@
 #include <Python.h>
 #include <structmember.h> // This defines the type id macros like T_STRING
 #ifdef USE_NUMPY
-#include "numpy/arrayobject.h"
+#include <numpy/arrayobject.h>
 #endif
 
 #include <iostream>


### PR DESCRIPTION
NumPy headers location was hardcoded, causing make to fail on OSX
and any other system with non-standard python library location.
This patch adds extraction of the proper path via invocation of
`numpy.get_include()`
Caveat: works for python 2.7 only at the moment