### PR TITLE
Follow up fixes to calcium-hsolve 

### DIFF
--- a/moose-core/biophysics/ChanCommon.cpp
+++ b/moose-core/biophysics/ChanCommon.cpp
@@ -111,6 +111,7 @@ void ChanCommon::sendProcessMsgs(  const Eref& e, const ProcPtr info )
 void ChanCommon::sendReinitMsgs(  const Eref& e, const ProcPtr info )
 {
 		ChanBase::channelOut()->send( e, Gk_, Ek_ );
+		ChanBase::IkOut()->send( e, Ik_ );
 	// Needed by GHK-type objects
 		ChanBase::permeability()->send( e, Gk_ );
 }

--- a/moose-core/biophysics/DifBuffer.cpp
+++ b/moose-core/biophysics/DifBuffer.cpp
@@ -235,6 +235,7 @@ void DifBuffer::vSetShapeMode(const Eref& e, unsigned int shapeMode )
     return;
   }
   shapeMode_ = shapeMode;
+  calculateVolumeArea(e);
 }
 
 unsigned int DifBuffer::vGetShapeMode(const Eref& e) const
@@ -250,6 +251,7 @@ void DifBuffer::vSetLength(const Eref& e, double length )
   }
 
   length_ = length;
+    calculateVolumeArea(e);
 }
 
 double DifBuffer::vGetLength(const Eref& e ) const
@@ -265,6 +267,7 @@ void DifBuffer::vSetDiameter(const Eref& e, double diameter )
   }
 
   diameter_ = diameter;
+  calculateVolumeArea(e);
 }
 
 double DifBuffer::vGetDiameter(const Eref& e ) const
@@ -280,6 +283,7 @@ void DifBuffer::vSetThickness( const Eref& e, double thickness )
   }
 
   thickness_ = thickness;
+  calculateVolumeArea(e);
 }
 
 double DifBuffer::vGetThickness(const Eref& e) const
@@ -360,7 +364,54 @@ double DifBuffer::integrate( double state, double dt, double A, double B )
 	}
 	return state + A * dt ;
 }
+void DifBuffer::calculateVolumeArea(const Eref& e)
+{
+double rOut = diameter_/2.;
+  
+  double rIn = rOut - thickness_;
 
+  if (rIn <0)
+	  rIn = 0.;
+  
+  switch ( shapeMode_ )
+    {
+      /*
+       * Onion Shell
+       */
+    case 0:
+      if ( length_ == 0.0 ) { // Spherical shell
+	volume_ = 4./3.* M_PI * ( rOut * rOut * rOut - rIn * rIn * rIn );
+	outerArea_ = 4*M_PI * rOut * rOut;
+	innerArea_ = 4*M_PI * rIn * rIn;
+      } else { // Cylindrical shell
+	volume_ = ( M_PI * length_  ) * ( rOut * rOut - rIn * rIn );
+	outerArea_ = 2*M_PI * rOut * length_;
+	innerArea_ = 2*M_PI * rIn * length_;
+      }
+		
+      break;
+	
+      /*
+       * Cylindrical Slice
+       */
+    case 1:
+      volume_ = M_PI * diameter_ * diameter_ * thickness_ / 4.0;
+      outerArea_ = M_PI * diameter_ * diameter_ / 4.0;
+      innerArea_ = outerArea_;
+      break;
+	
+      /*
+       * User defined
+       */
+    case 3:
+      // Nothing to be done here. Volume and inner-, outer areas specified by
+      // user.
+      break;
+	
+    default:
+      assert( 0 );
+    }
+}
 
 void DifBuffer::vProcess( const Eref & e, ProcPtr p )
 {

--- a/moose-core/biophysics/DifBuffer.h
+++ b/moose-core/biophysics/DifBuffer.h
@@ -61,7 +61,8 @@ class DifBuffer: public DifBufferBase{
 
   void vSetInnerArea(const Eref& e, double innerArea );
   double vGetInnerArea(const Eref& e) const;
-  
+
+  void   calculateVolumeArea(const Eref& e);
   static const Cinfo * initCinfo();
 
  private:

--- a/moose-core/biophysics/DifShell.h
+++ b/moose-core/biophysics/DifShell.h
@@ -73,6 +73,9 @@ class DifShell: public DifShellBase{
 
   void vSetInnerArea(const Eref& e, double innerArea );
   double vGetInnerArea(const Eref& e) const;
+
+  void calculateVolumeArea(const Eref& e);
+  
   static const Cinfo * initCinfo();
   
                 

--- a/moose-core/biophysics/HHChannel.cpp
+++ b/moose-core/biophysics/HHChannel.cpp
@@ -322,12 +322,12 @@ void HHChannel::vProcess( const Eref& e, ProcPtr info )
 	}
 
 	ChanCommon::vSetGk( e, g_ * HHChannelBase::modulation_ );
-	this->updateIk();
+	ChanCommon::updateIk();
 	// Gk_ = g_;
 	// Ik_ = ( Ek_ - Vm_ ) * g_;
 
 	// Send out the relevant channel messages.
-	sendProcessMsgs( e, info );
+	ChanCommon::sendProcessMsgs( e, info );
 	
 	g_ = 0.0;
 }
@@ -386,13 +386,13 @@ void HHChannel::vReinit( const Eref& er, ProcPtr info )
 	}
 
 	ChanCommon::vSetGk( er, g_ * HHChannelBase::modulation_ );
-	updateIk();
+	ChanCommon::updateIk();
 	// Gk_ = g_;
 	// Ik_ = ( Ek_ - Vm_ ) * g_;
 
 	// Send out the relevant channel messages.
 	// Same for reinit as for process.
-	sendReinitMsgs( er, info );
+	ChanCommon::sendReinitMsgs( er, info );
 	
 	g_ = 0.0;
 }

--- a/moose-core/hsolve/HSolveInterface.cpp
+++ b/moose-core/hsolve/HSolveInterface.cpp
@@ -246,7 +246,8 @@ void HSolve::addGkEk( Id id, double Gk, double Ek )
 void HSolve::addConc( Id id, double conc )
 {
     unsigned int index = localIndex( id );
-    assert(  index + 1 < externalCalcium_.size() );
+    assert(  index < externalCalcium_.size() );
+  
     externalCalcium_[ index ] = conc;
 }
 


### PR DESCRIPTION
Fix assertion failure in HSolveInterface.cpp
Add functions calculating volume to DifShell and DifBuffer. Volume was calculated at reinit. I have noticed that in more complicated models sometimes there is a diffusion message before volume calcuation, which results in division by zero.
Add sending out current message in channel reinit.